### PR TITLE
Removed unused dependencies; added output overwrite mode.

### DIFF
--- a/get_dependencies.sh
+++ b/get_dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 INSTALL_COMMAND="sudo pip-3.4 install"
-dependencies="warcio requests requests_file boto3 botocore py4j"
+dependencies="warcio boto3 botocore py4j"
 
 for dep in $dependencies; do
     $INSTALL_COMMAND $dep


### PR DESCRIPTION
Some cleaning up and now Spark will never again fail and complain about an already existing output directory (after provisioning and bootstrapping for a painfully long while).